### PR TITLE
Ensure Tk destroyed when selecting file

### DIFF
--- a/abrir_mi_resumen.py
+++ b/abrir_mi_resumen.py
@@ -36,7 +36,8 @@ def select_file():
     root = Tk()
     root.withdraw()  # Hide the main window
     file_path = filedialog.askopenfilename()  # Show the file open dialog
-    root.destroy()  # Close the Tkinter root window
+    # Destroy the Tk instance before returning the selected path
+    root.destroy()
     return file_path
 
 def guess_password(pdf_file, digits):


### PR DESCRIPTION
## Summary
- tidy up `select_file` to destroy the Tk window after retrieving the chosen path

## Testing
- `python -m py_compile abrir_mi_resumen.py`

------
https://chatgpt.com/codex/tasks/task_e_684e4501e238832ead60f67bd60639be